### PR TITLE
Fix subprocess recursion handling

### DIFF
--- a/ENHANCED_NO_CONSOLE_PATCH.py
+++ b/ENHANCED_NO_CONSOLE_PATCH.py
@@ -157,6 +157,7 @@ else:
     subprocess._manimstudio_patched = True
     subprocess._original_run = _original_run  # Store reference to original
     subprocess._original_popen = _original_popen  # Store reference to original
+    subprocess._original_stored = True
 
     print("Subprocess patching complete - all console windows will be hidden")
 

--- a/process_utils.py
+++ b/process_utils.py
@@ -5,7 +5,7 @@ import os
 
 # Store original references to subprocess functions before they get patched
 # This ensures we always have direct access to the original functions
-if not hasattr(subprocess, '_original_stored'):
+if not hasattr(subprocess, '_original_run'):
     subprocess._original_run = subprocess.run
     subprocess._original_popen = subprocess.Popen
     subprocess._original_call = subprocess.call

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+manim[complete]>=0.17.3
+customtkinter>=5.2.0
+pillow>=10.0.0
+numpy>=1.24.3
+opencv-python>=4.8.0
+matplotlib>=3.7.2
+scipy>=1.11.1
+jedi>=0.18.2
+requests>=2.31.0
+aiohttp>=3.8.5
+sympy>=1.12
+networkx>=3.1
+pyinstaller>=5.10.1


### PR DESCRIPTION
## Summary
- prevent recursion when importing process utilities before patch
- update the console-hiding patch to set `_original_stored`

## Testing
- `python -m py_compile app.py`
- `python -m py_compile ENHANCED_NO_CONSOLE_PATCH.py process_utils.py`
