### PR TITLE
Fix subprocess recursion issue when creating environments

### DIFF
--- a/process_utils.py
+++ b/process_utils.py
@@ -6,11 +6,14 @@ import os
 # Store original references to subprocess functions before they get patched
 # This ensures we always have direct access to the original functions
 if not hasattr(subprocess, '_original_stored'):
-    subprocess._original_run = subprocess.run
-    subprocess._original_popen = subprocess.Popen
-    subprocess._original_call = subprocess.call
-    subprocess._original_check_output = subprocess.check_output
-    subprocess._original_check_call = subprocess.check_call
+    # If another module already stored the original functions (e.g. a patch
+    # that hides console windows), re-use those references. Otherwise store the
+    # current implementations which should still be the unpatched ones.
+    subprocess._original_run = getattr(subprocess, '_original_run', subprocess.run)
+    subprocess._original_popen = getattr(subprocess, '_original_popen', subprocess.Popen)
+    subprocess._original_call = getattr(subprocess, '_original_call', subprocess.call)
+    subprocess._original_check_output = getattr(subprocess, '_original_check_output', subprocess.check_output)
+    subprocess._original_check_call = getattr(subprocess, '_original_check_call', subprocess.check_call)
     subprocess._original_stored = True
 
 def run_hidden_process(command, **kwargs):


### PR DESCRIPTION
## Summary
- guard against patch order issues in `process_utils`
- re-use stored subprocess originals if available to avoid recursion
- set media directory relative to application directory so output always goes next to the app

## Testing
- `python -m py_compile process_utils.py ENHANCED_NO_CONSOLE_PATCH.py app.py`
- `python - <<'EOF'
import subprocess, sys, venv, tempfile, os
import process_utils
import ENHANCED_NO_CONSOLE_PATCH
import shutil
path = tempfile.mkdtemp(prefix='testenv')
venv.create(path, with_pip=True)
shutil.rmtree(path)
EOF`