### PR TITLE
Use Mono Terminals helper

### DIFF
--- a/mono.py
+++ b/mono.py
@@ -1,0 +1,27 @@
+import os
+import shlex
+import subprocess
+from process_utils import popen_original
+
+class Terminals:
+    """Lightweight helper for launching subprocesses in a consistent way."""
+
+    @staticmethod
+    def popen(command, cwd=None, env=None):
+        """Return a Popen object for the given command."""
+        if isinstance(command, str):
+            args = shlex.split(command, posix=(os.name != 'nt'))
+        else:
+            args = list(command)
+        return popen_original(
+            args,
+            shell=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            cwd=cwd,
+            env=env,
+            universal_newlines=True
+        )
+
+__all__ = ["Terminals"]


### PR DESCRIPTION
## Summary
- switch built-in terminal to use `mono.Terminals` helper
- avoid premature f-string in package verification script
- provide lightweight `mono.Terminals` implementation

## Testing
- `python -m py_compile app.py process_utils.py build_config.py ENHANCED_NO_CONSOLE_PATCH.py fixes.py create_installer_fast.py build_nuitka.py mono.py`
