### PR TITLE
Fix LaTeX env initialization

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,6 +53,15 @@ import queue
 import atexit
 from tkinter import filedialog, messagebox
 
+# Try to import advanced LaTeX configuration generated during the
+# Nuitka build.  This module sets up the bundled LaTeX environment when
+# imported.  If it is missing (e.g. when running from source), we simply
+# continue without it.
+try:
+    import advanced_latex_config  # noqa: F401
+except Exception as e:  # pragma: no cover - optional dependency
+    print(f"Warning: Advanced LaTeX configuration not available ({e})")
+
 # Determine base directory of the running script or executable
 if getattr(sys, 'frozen', False):
     BASE_DIR = os.path.dirname(os.path.abspath(sys.executable))


### PR DESCRIPTION
## Summary
- load the `advanced_latex_config` module at startup if present

## Testing
- `python -m py_compile app.py build_nuitka.py fixes.py process_utils.py`

------
https://chatgpt.com/codex/tasks/task_b_68423571c61c8327a95108d3b9004ed6