### PR TITLE
Improve local LaTeX detection

### DIFF
--- a/app.py
+++ b/app.py
@@ -108,6 +108,20 @@ if not _ADV_LATEX_OK:
                             os.environ["TEXMFHOME"] = str(texmf[0])
                         print(f"Configured local LaTeX from {existing}")
                         return True
+                # Fallback search when no 'bin' directory is present
+                for sub in existing.rglob("*"):
+                    if not sub.is_dir():
+                        continue
+                    if (sub / "latex.exe").exists() or (sub / "latex").exists():
+                        cur = os.environ.get("PATH", "")
+                        if str(sub) not in cur:
+                            os.environ["PATH"] = str(sub) + os.pathsep + cur
+                        os.environ["LATEX_ROOT"] = str(existing)
+                        texmf = list(existing.rglob("*texmf*"))
+                        if texmf:
+                            os.environ["TEXMFHOME"] = str(texmf[0])
+                        print(f"Configured local LaTeX from {existing}")
+                        return True
         return False
 
     if not _configure_local_latex():


### PR DESCRIPTION
## Summary
- enhance `_configure_local_latex` to search for `latex` binaries even when no `bin` directory exists

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68445e63853483278103b1c649b32990