### PR TITLE
Refactor latex template env var

### DIFF
--- a/fixes.py
+++ b/fixes.py
@@ -60,8 +60,8 @@ def fix_manim_config():
     and a minimal TeX template that does not rely on the ``standalone``
     LaTeX class.  The template is written to ``tex_template.tex`` in the
     same directory as ``default.cfg`` and the path is exposed via the
-    ``MANIM_TEX_TEMPLATE_PATH`` environment variable so that Manim can
-    pick it up at runtime.
+    ``MANIM_TEX_TEMPLATE`` environment variable so that Manim can pick it
+    up at runtime.
     """
     try:
         # For packaged app - find the temp directory where files are extracted
@@ -97,7 +97,7 @@ def fix_manim_config():
                 return False
 
             # Expose the template path so other modules can use it
-            os.environ['MANIM_TEX_TEMPLATE_PATH'] = template_path
+            os.environ['MANIM_TEX_TEMPLATE'] = template_path
 
             print(f"Created manim config at: {default_cfg_path}")
             return True
@@ -232,7 +232,7 @@ def patch_subprocess():
 def patch_manim_latex():
     """Apply custom LaTeX template if available."""
     try:
-        template_path = os.environ.get('MANIM_TEX_TEMPLATE_PATH')
+        template_path = os.environ.get('MANIM_TEX_TEMPLATE')
         if not template_path or not os.path.exists(template_path):
             return False
 


### PR DESCRIPTION
## Summary
- reference MANIM_TEX_TEMPLATE instead of MANIM_TEX_TEMPLATE_PATH
- update comment explaining the env variable
- load the template path from the new environment variable

## Testing
- `python -m py_compile fixes.py`
- `python - <<'EOF'
import types, sys, os, tempfile
manim = types.ModuleType('manim'); manim.config = types.SimpleNamespace(tex_template=None)
tex_templates = types.ModuleType('manim.utils.tex_templates')
class TexTemplate: pass
tex_templates.TexTemplate = TexTemplate
sys.modules['manim'] = manim
sys.modules['manim.utils.tex_templates'] = tex_templates
fp = tempfile.NamedTemporaryFile('w', delete=False); fp.write('test template'); fp.close()
os.environ['MANIM_TEX_TEMPLATE'] = fp.name
import fixes; print(fixes.patch_manim_latex(), manim.config.tex_template.text)
EOF`

------
https://chatgpt.com/codex/tasks/task_b_68459be4783c832796b0635de4920944