### PR TITLE
Fix Nuitka onefile subprocess flags and persistent venv path

### DIFF
--- a/build_nuitka.py
+++ b/build_nuitka.py
@@ -712,7 +712,8 @@ def build_onefile_executable(jobs=None, priority="normal"):
         "--disable-dll-dependency-cache",
         "--windows-force-stdout-spec=nul",
         "--windows-force-stderr-spec=nul",
-        "--windows-onefile-tempdir-spec=CACHE",
+        # '--windows-onefile-tempdir-spec' is not recognized on older Nuitka
+        # versions, so only use the generic option that works cross-platform
         "--onefile-tempdir-spec={TEMP}\\nuitka-onefile-{PID}",
     ]
 

--- a/build_nuitka.py
+++ b/build_nuitka.py
@@ -710,6 +710,10 @@ def build_onefile_executable(jobs=None, priority="normal"):
         "--disable-ccache",
         "--show-memory",
         "--disable-dll-dependency-cache",
+        "--windows-force-stdout-spec=nul",
+        "--windows-force-stderr-spec=nul",
+        "--windows-onefile-tempdir-spec=CACHE",
+        "--onefile-tempdir-spec={TEMP}\\nuitka-onefile-{PID}",
     ]
 
     # MINIMAL exclusions - only exclude test modules
@@ -728,6 +732,14 @@ def build_onefile_executable(jobs=None, priority="normal"):
 
     for module in minimal_exclusions:
         cmd.append(f"--nofollow-import-to={module}")
+
+    # Ensure subprocess related modules are included for onefile safety
+    cmd.extend([
+        "--include-module=subprocess",
+        "--include-module=threading",
+        "--include-module=tempfile",
+        "--include-module=os",
+    ])
 
     # Include ALL packages
     comprehensive_packages = [


### PR DESCRIPTION
## Summary
- store virtual environments under `~/.manim_studio/venvs`
- run subprocesses with safer flags and environment variables
- look for venvs in persistent path first
- expose helper to create a virtual environment in persistent path
- add windows onefile flags and ensure subprocess modules included in build

## Testing
- `python -m py_compile app.py build_nuitka.py`

------
https://chatgpt.com/codex/tasks/task_b_684ba29600d08327aac3abce6b019bde