### PR TITLE
Fix virtual environment detection

### DIFF
--- a/app.py
+++ b/app.py
@@ -4303,8 +4303,9 @@ else:
         
         if os.name == 'nt':
             # Windows candidates - prioritize 64-bit installations
+            if not self.is_frozen:
+                candidates.append(sys.executable)
             candidates.extend([
-                sys.executable,
                 "python",
                 "python3"
             ])
@@ -4324,8 +4325,9 @@ else:
                 
         else:
             # Unix-like candidates
+            if not self.is_frozen:
+                candidates.append(sys.executable)
             candidates.extend([
-                sys.executable,
                 "python3",
                 "python",
                 "/usr/bin/python3",
@@ -4341,6 +4343,10 @@ else:
                 elif shutil.which(candidate):
                     python_path = shutil.which(candidate)
                 else:
+                    continue
+
+                if self.is_frozen and os.path.samefile(python_path, sys.executable):
+                    self.logger.debug("Skipping frozen executable candidate")
                     continue
                 
                 # Check Python version
@@ -5560,9 +5566,9 @@ else:
     def _find_best_python(self):
         """Find the best Python executable available on the system"""
         try:
-            # First try the current Python executable
+            # First try the current Python executable when not frozen
             current_python = sys.executable
-            if current_python and os.path.exists(current_python):
+            if not self.is_frozen and current_python and os.path.exists(current_python):
                 self.logger.info(f"Using current Python executable: {current_python}")
                 return current_python
             

--- a/app.py
+++ b/app.py
@@ -2226,6 +2226,8 @@ class EnvironmentSetupDialog(ctk.CTkToplevel):
             ):
                 self.destroy()
         else:
+            # Mark setup as completed when closing after success
+            self.venv_manager.needs_setup = False
             self.destroy()
 
 class EnhancedVenvManagerDialog(ctk.CTkToplevel):


### PR DESCRIPTION
## Summary
- avoid using the frozen executable when looking for a Python interpreter
- skip the built executable in `_find_best_python`

## Testing
- `python -m py_compile app.py build_nuitka.py`
- `flake8` *(fails: many style violations)*

------
https://chatgpt.com/codex/tasks/task_b_685652af4ea88327a5fe4b87faeed73b