### PR TITLE
Use cmd.exe for command execution

### DIFF
--- a/index.html
+++ b/index.html
@@ -1037,7 +1037,7 @@ class MyAnimation(Scene):
                 // Create a temp file and execute with secure API
                 const tempContent = `${content}\n\n# Auto-generated preview code\nif __name__ == "__main__":\n    scene = MyAnimation()\n    scene.render()`;
                 
-                // Execute using secure API (the main process will handle temp file creation)
+                // Execute using secure API (main process runs via cmd.exe on Windows)
                 if (window.electronAPI) {
                     const command = `python -c "${tempContent.replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`;
                     await window.electronAPI.executeCommand(command);
@@ -1079,6 +1079,7 @@ class MyAnimation(Scene):
                 // Create render command with quality settings
                 const renderContent = `${content}\n\n# Auto-generated render code\nif __name__ == "__main__":\n    scene = MyAnimation()\n    scene.render()`;
                 
+                // Forward the render command to the main process (uses cmd.exe on Windows)
                 if (window.electronAPI) {
                     const command = `python -c "${renderContent.replace(/"/g, '\\"').replace(/\n/g, '\\n')}" --${quality} --fps ${fps}`;
                     await window.electronAPI.executeCommand(command);

--- a/main.js
+++ b/main.js
@@ -417,11 +417,22 @@ async function executeTerminalCommand(command, cwd = process.cwd()) {
 
         console.log('🌍 Environment PATH:', enhancedEnv.PATH.split(';').slice(0, 3).join(';') + '...');
 
-        const childProcess = spawn(finalCommand, [], {
+        // Use cmd.exe directly on Windows to execute the command
+        const isWin = process.platform === 'win32';
+        const shell = isWin ? 'cmd.exe' : '/bin/sh';
+
+        let commandStr = finalCommand;
+        if (isWin && commandStr.toLowerCase().startsWith('cmd.exe')) {
+            commandStr = commandStr.replace(/^cmd\.exe\s*/i, '');
+        }
+
+        const args = isWin ? ['/d', '/s', '/c', commandStr] : ['-c', commandStr];
+
+        const childProcess = spawn(shell, args, {
             cwd: cwd,
-            shell: true,
             stdio: ['pipe', 'pipe', 'pipe'],
-            env: enhancedEnv
+            env: enhancedEnv,
+            windowsHide: true
         });
 
         childProcess.stdout.on('data', (data) => {


### PR DESCRIPTION
## Summary
- Execute shell commands through cmd.exe on Windows for preview and render actions
- Note cmd.exe usage in preview and render logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a2a35d93f483279d3e1afcf54f4230